### PR TITLE
Higher-order predicate macros

### DIFF
--- a/.fenneldoc
+++ b/.fenneldoc
@@ -8,7 +8,7 @@
 
  :test-requirements
  {"bunko/macros.fnl"
-  "(import-macros {: assert-type : map-values : unless : immutably : find-any : any} :bunko.macros)"
+  "(import-macros {: assert-type : map-values : unless : immutably : find-some : for-some?} :bunko.macros)"
   "bunko/string.fnl"
   "(import-macros {: assert-type} :bunko.macros)"
   "bunko/file.fnl"
@@ -25,8 +25,8 @@
                :assert-type
                :map-values
                :immutably
-               :find-any
-               :any]}
+               :find-some
+               :for-some?]}
 
   "bunko/string.fnl"
   {:description "Utilities for string manipulation."

--- a/.fenneldoc
+++ b/.fenneldoc
@@ -8,7 +8,14 @@
 
  :test-requirements
  {"bunko/macros.fnl"
-  "(import-macros {: assert-type : map-values : unless : immutably : find-some : for-some?} :bunko.macros)"
+  "(import-macros {: assert-type
+                   : map-values
+                   : unless
+                   : immutably
+                   : find-some
+                   : for-some?
+                   : for-all?}
+                  :bunko.macros)"
   "bunko/string.fnl"
   "(import-macros {: assert-type} :bunko.macros)"
   "bunko/file.fnl"
@@ -26,7 +33,8 @@
                :map-values
                :immutably
                :find-some
-               :for-some?]}
+               :for-some?
+               :for-all?]}
 
   "bunko/string.fnl"
   {:description "Utilities for string manipulation."

--- a/.fenneldoc
+++ b/.fenneldoc
@@ -8,7 +8,7 @@
 
  :test-requirements
  {"bunko/macros.fnl"
-  "(import-macros {: assert-type : map-values : unless : immutably : find-any} :bunko.macros)"
+  "(import-macros {: assert-type : map-values : unless : immutably : find-any : any} :bunko.macros)"
   "bunko/string.fnl"
   "(import-macros {: assert-type} :bunko.macros)"
   "bunko/file.fnl"
@@ -25,7 +25,8 @@
                :assert-type
                :map-values
                :immutably
-               :find-any]}
+               :find-any
+               :any]}
 
   "bunko/string.fnl"
   {:description "Utilities for string manipulation."

--- a/.fenneldoc
+++ b/.fenneldoc
@@ -8,7 +8,7 @@
 
  :test-requirements
  {"bunko/macros.fnl"
-  "(import-macros {: assert-type : map-values : unless : immutably} :bunko.macros)"
+  "(import-macros {: assert-type : map-values : unless : immutably : find-any} :bunko.macros)"
   "bunko/string.fnl"
   "(import-macros {: assert-type} :bunko.macros)"
   "bunko/file.fnl"
@@ -24,7 +24,8 @@
    :doc-order [:unless
                :assert-type
                :map-values
-               :immutably]}
+               :immutably
+               :find-any]}
 
   "bunko/string.fnl"
   {:description "Utilities for string manipulation."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning][2].
 
 ## Unreleased
 
+### Added
+
+- `find-some`, `for-some?`, and `for-all?` macros
+  - For a given iterator,
+    - `find-some` finds one example that satisfies a given predicate expression,
+    - `for-some?` tests the above and returns boolean instead, and
+    - `for-all?` tests a predicate expression is satisfied for all examples.
+
 ## [0.1.0][v0.1.0] (2024-02-24)
 
 - Initial release of development version.

--- a/bunko/macros.fnl
+++ b/bunko/macros.fnl
@@ -184,4 +184,36 @@ implicitly in this macro.
     `(let [found# (accumulate ,iter-tbl (when ,pred-expr ,kv-tbl))]
        (when found# (,%unpack found#)))))
 
-{: assert-type : map-values : unless : immutably : find-any}
+(fn any [iter-tbl pred-expr ...]
+  "Test if a predicate expression is truthy for any example yielded by an iterator.
+
+Similar to `find-any`, it runs through an iterator and in each step evaluates a
+`predicate-expression`. If the evaluated result is truthy, it immediately returns
+`true`; otherwise returns `false`.
+
+Note that the `bindings` cannot have `&until` clause as the clause will be inserted
+implicitly in this macro.
+
+# Examples
+
+```fennel
+(let [q (any [_ n (ipairs [:a 1 {} 2])]
+          (= (type n) :number)) ;=> true
+      ]
+  (assert (= true q)))
+```"
+  {:fnl/arglist [bindings predicate-expression]}
+  (assert (and (sequence? iter-tbl) (<= 2 (length iter-tbl)))
+          "expected iterator binding table")
+  (assert (not= nil pred-expr) "expected predicate expression")
+  (assert (= nil ...)
+          "expected only one expression; wrap multiple expressions with do")
+  (let [found `found#
+        iter-tbl (doto (copy iter-tbl)
+                   (table.insert 1 found)
+                   (table.insert 2 `false)
+                   (table.insert `&until)
+                   (table.insert found))]
+    `(accumulate ,iter-tbl (if ,pred-expr true ,found))))
+
+{: assert-type : map-values : unless : immutably : find-any : any}

--- a/bunko/macros.fnl
+++ b/bunko/macros.fnl
@@ -145,11 +145,11 @@ Note that it does not set the metatable of the copy to the original.
          (,mutate! ,(unpack args))))))
 
 (fn find-some [iter-tbl pred-expr ...]
-  "Find some values yielded by an iterator on which a predicate expression returns true.
+  "Find some values yielded by an iterator on which a predicate expression is truthy.
 
 It runs through an iterator and in each step evaluates a `predicate-expression`.
-If the evaluated result is truthy, it immediately returns the (multiple) values
-yielded by the iterator.
+If the evaluated result is truthy, it immediately returns the value(s) yielded
+by the iterator.
 
 Note that the `bindings` cannot have `&until` clause as the clause will be inserted
 implicitly in this macro.
@@ -219,7 +219,7 @@ implicitly in this macro.
 (fn for-all? [iter-tbl pred-expr ...]
   "Test if a predicate expression is truthy for all yielded by an iterator.
 
-Similar to `for-some`, but it checks whether a `predicate-expression` is truthy
+Similar to `for-some?`, but it checks whether a `predicate-expression` is truthy
 for all yielded by the iterator. If so, it returns `true`, otherwise returns `false`.
 
 Note that the `bindings` cannot have `&until` clause as the clause will be inserted

--- a/bunko/macros.fnl
+++ b/bunko/macros.fnl
@@ -144,8 +144,8 @@ Note that it does not set the metatable of the copy to the original.
        (doto clone#
          (,mutate! ,(unpack args))))))
 
-(fn find-any [iter-tbl pred-expr ...]
-  "Find any values yielded by an iterator on which a predicate expression returns true.
+(fn find-some [iter-tbl pred-expr ...]
+  "Find some values yielded by an iterator on which a predicate expression returns true.
 
 It runs through an iterator and in each step evaluates a `predicate-expression`.
 If the evaluated result is truthy, it immediately returns the (multiple) values
@@ -157,12 +157,12 @@ implicitly in this macro.
 # Examples
 
 ```fennel
-(let [(i v) (find-any [_ n (ipairs [:a 1 {} 2])]
+(let [(i v) (find-some [_ n (ipairs [:a 1 {} 2])]
               (= (type n) :number)) ;=> 2\t1
       ]
   (assert (and (= i 2) (= v 1))))
 
-(let [(k v) (find-any [k v (pairs {:a :A :b {} :c :cc})]
+(let [(k v) (find-some [k v (pairs {:a :A :b {} :c :cc})]
               (and (= (type v) :string)
                    (: v :match (.. \"^\" k)))) ;=> :c\t:cc
       ]
@@ -184,10 +184,10 @@ implicitly in this macro.
     `(let [found# (accumulate ,iter-tbl (when ,pred-expr ,kv-tbl))]
        (when found# (,%unpack found#)))))
 
-(fn any [iter-tbl pred-expr ...]
-  "Test if a predicate expression is truthy for any example yielded by an iterator.
+(fn for-some? [iter-tbl pred-expr ...]
+  "Test if a predicate expression is truthy for some example yielded by an iterator.
 
-Similar to `find-any`, it runs through an iterator and in each step evaluates a
+Similar to `find-some`, it runs through an iterator and in each step evaluates a
 `predicate-expression`. If the evaluated result is truthy, it immediately returns
 `true`; otherwise returns `false`.
 
@@ -197,7 +197,7 @@ implicitly in this macro.
 # Examples
 
 ```fennel
-(let [q (any [_ n (ipairs [:a 1 {} 2])]
+(let [q (for-some? [_ n (ipairs [:a 1 {} 2])]
           (= (type n) :number)) ;=> true
       ]
   (assert (= true q)))
@@ -216,4 +216,4 @@ implicitly in this macro.
                    (table.insert found))]
     `(accumulate ,iter-tbl (if ,pred-expr true ,found))))
 
-{: assert-type : map-values : unless : immutably : find-any : any}
+{: assert-type : map-values : unless : immutably : find-some : for-some?}

--- a/bunko/macros.fnl
+++ b/bunko/macros.fnl
@@ -216,4 +216,41 @@ implicitly in this macro.
                    (table.insert found))]
     `(accumulate ,iter-tbl (if ,pred-expr true ,found))))
 
-{: assert-type : map-values : unless : immutably : find-some : for-some?}
+(fn for-all? [iter-tbl pred-expr ...]
+  "Test if a predicate expression is truthy for all yielded by an iterator.
+
+Similar to `for-some`, but it checks whether a `predicate-expression` is truthy
+for all yielded by the iterator. If so, it returns `true`, otherwise returns `false`.
+
+Note that the `bindings` cannot have `&until` clause as the clause will be inserted
+implicitly in this macro.
+
+# Examples
+
+```fennel
+(let [q (for-all? [_ n (ipairs [:a 1 {} 2])]
+          (= (type n) :number)) ;=> false
+      ]
+  (assert (= false q)))
+```"
+  {:fnl/arglist [bindings predicate-expression]}
+  (assert (and (sequence? iter-tbl) (<= 2 (length iter-tbl)))
+          "expected iterator binding table")
+  (assert (not= nil pred-expr) "expected predicate expression")
+  (assert (= nil ...)
+          "expected only one expression; wrap multiple expressions with do")
+  (let [found `found#
+        iter-tbl (doto (copy iter-tbl)
+                   (table.insert 1 found)
+                   (table.insert 2 `true)
+                   (table.insert `&until)
+                   (table.insert `(not ,found)))]
+    `(accumulate ,iter-tbl (if ,pred-expr ,found false))))
+
+{: assert-type
+ : map-values
+ : unless
+ : immutably
+ : find-some
+ : for-some?
+ : for-all?}

--- a/test/macros.fnl
+++ b/test/macros.fnl
@@ -1,6 +1,10 @@
 (local t (require :faith))
-(import-macros {: assert-type : map-values : unless : immutably : find-any}
-               :bunko.macros)
+(import-macros {: assert-type
+                : map-values
+                : unless
+                : immutably
+                : find-any
+                : any} :bunko.macros)
 
 (fn test-assert-type []
   (let [x {:a 1}
@@ -40,8 +44,14 @@
     (t.is (or (= :b k) (= :c k))) ; Iterator may generate values in random order.
     (t.= :b v)))
 
+(fn test-any []
+  (t.= true (any [_ n (ipairs [2 2 3 5])] (= (% n 2) 1)))
+  (t.= false (any [k v (pairs {:a 1 :b 2})] (= k :z)))
+  (t.= false (any [_ n (ipairs [])] (= (% n 2) 1))))
+
 {: test-assert-type
  : test-map-values
  : test-unless
  : test-immutably
- : test-find-any}
+ : test-find-any
+ : test-any}

--- a/test/macros.fnl
+++ b/test/macros.fnl
@@ -1,5 +1,6 @@
 (local t (require :faith))
-(import-macros {: assert-type : map-values : unless : immutably} :bunko.macros)
+(import-macros {: assert-type : map-values : unless : immutably : find-any}
+               :bunko.macros)
 
 (fn test-assert-type []
   (let [x {:a 1}
@@ -31,4 +32,16 @@
     (t.= [1 2] (immutably table.insert x 2))
     (t.= [1] x)))
 
-{: test-assert-type : test-map-values : test-unless : test-immutably}
+(fn test-find-any []
+  (let [(k v) (find-any [_ n (ipairs [2 2 3 5])] (= (% n 2) 1))]
+    (t.= 3 k)
+    (t.= 3 v))
+  (let [(k v) (find-any [k v (pairs {:a 1 :b :b :c :b})] (= v :b))]
+    (t.is (or (= :b k) (= :c k))) ; Iterator may generate values in random order.
+    (t.= :b v)))
+
+{: test-assert-type
+ : test-map-values
+ : test-unless
+ : test-immutably
+ : test-find-any}

--- a/test/macros.fnl
+++ b/test/macros.fnl
@@ -4,7 +4,8 @@
                 : unless
                 : immutably
                 : find-some
-                : for-some?} :bunko.macros)
+                : for-some?
+                : for-all?} :bunko.macros)
 
 (fn test-assert-type []
   (let [x {:a 1}
@@ -49,9 +50,15 @@
   (t.= false (for-some? [k v (pairs {:a 1 :b 2})] (= k :z)))
   (t.= false (for-some? [_ n (ipairs [])] (= (% n 2) 1))))
 
+(fn test-for-all? []
+  (t.= true (for-all? [_ n (ipairs [1 3 3 5])] (= (% n 2) 1)))
+  (t.= false (for-all? [k v (pairs {:a 1 :b 2})] (= k :a)))
+  (t.= true (for-all? [_ n (ipairs [])] (= (% n 2) 1)))) ; vacuous truth
+
 {: test-assert-type
  : test-map-values
  : test-unless
  : test-immutably
  : test-find-some
- : test-for-some?}
+ : test-for-some?
+ : test-for-all?}

--- a/test/macros.fnl
+++ b/test/macros.fnl
@@ -53,7 +53,8 @@
 (fn test-for-all? []
   (t.= true (for-all? [_ n (ipairs [1 3 3 5])] (= (% n 2) 1)))
   (t.= false (for-all? [k v (pairs {:a 1 :b 2})] (= k :a)))
-  (t.= true (for-all? [_ n (ipairs [])] (= (% n 2) 1)))) ; vacuous truth
+  ;; vacuous truth
+  (t.= true (for-all? [_ n (ipairs [])] (= (% n 2) 1))))
 
 {: test-assert-type
  : test-map-values

--- a/test/macros.fnl
+++ b/test/macros.fnl
@@ -3,8 +3,8 @@
                 : map-values
                 : unless
                 : immutably
-                : find-any
-                : any} :bunko.macros)
+                : find-some
+                : for-some?} :bunko.macros)
 
 (fn test-assert-type []
   (let [x {:a 1}
@@ -36,22 +36,22 @@
     (t.= [1 2] (immutably table.insert x 2))
     (t.= [1] x)))
 
-(fn test-find-any []
-  (let [(k v) (find-any [_ n (ipairs [2 2 3 5])] (= (% n 2) 1))]
+(fn test-find-some []
+  (let [(k v) (find-some [_ n (ipairs [2 2 3 5])] (= (% n 2) 1))]
     (t.= 3 k)
     (t.= 3 v))
-  (let [(k v) (find-any [k v (pairs {:a 1 :b :b :c :b})] (= v :b))]
+  (let [(k v) (find-some [k v (pairs {:a 1 :b :b :c :b})] (= v :b))]
     (t.is (or (= :b k) (= :c k))) ; Iterator may generate values in random order.
     (t.= :b v)))
 
-(fn test-any []
-  (t.= true (any [_ n (ipairs [2 2 3 5])] (= (% n 2) 1)))
-  (t.= false (any [k v (pairs {:a 1 :b 2})] (= k :z)))
-  (t.= false (any [_ n (ipairs [])] (= (% n 2) 1))))
+(fn test-for-some? []
+  (t.= true (for-some? [_ n (ipairs [2 2 3 5])] (= (% n 2) 1)))
+  (t.= false (for-some? [k v (pairs {:a 1 :b 2})] (= k :z)))
+  (t.= false (for-some? [_ n (ipairs [])] (= (% n 2) 1))))
 
 {: test-assert-type
  : test-map-values
  : test-unless
  : test-immutably
- : test-find-any
- : test-any}
+ : test-find-some
+ : test-for-some?}


### PR DESCRIPTION
Introduces three macros: `find`, `any`, and `every`.

From an iterator, `find` finds any one example pair of values that satisfy the predicate expression, which is specified in the macro body; `any` is a variant of `find`, which returns boolean instead; `every` checks if all the pairs of values the iterator generates satisfy the predicate, and returns again boolean.

### Example use cases

```fennel
(find [_ n (ipairs [:a 1 {} 2])]
  (= (type n) :number))
;=> 2    1

(any [_ n (ipairs [:a 1 {} 2])]
  (= (type n) :number))
;=> true

(every [_ n (ipairs [:a 1 {} 2])]
  (= (type n) :number))
;=> false
```